### PR TITLE
imageView's contentMode Fix

### DIFF
--- a/ImageCropView/ImageCropView.m
+++ b/ImageCropView/ImageCropView.m
@@ -235,6 +235,8 @@ CGRect SquareCGRectAtCenter(CGFloat centerX, CGFloat centerY, CGFloat size) {
     
     //the image
     imageView = [[UIImageView alloc] initWithFrame:subviewFrame];
+    imageView.contentMode = UIViewContentModeScaleAspectFill;
+
 
     //control points
     controlPointSize = DEFAULT_CONTROL_POINT_SIZE;


### PR DESCRIPTION
Set the imageView's contentMode to ScaleAspectFill in order to fix a bug that stretched the image inside the crop rect. This bug only affected portrait images.
